### PR TITLE
fix piano crash on windows and linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ target_compile_definitions (${PLUGIN_NAME} PRIVATE
 								JucePlugin_PreferredChannelConfigurations={0,2}
 								_CRT_SECURE_NO_WARNINGS
 							)
+set(TARGET ${PLUGIN_NAME} PRIVATE CMAKE_CXX_STANDARD 20)
 
 if (APPLE)
 	set_target_properties("juce_vst3_helper" PROPERTIES XCODE_ATTRIBUTE_CLANG_LINK_OBJC_RUNTIME NO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,7 @@ target_compile_definitions (${PLUGIN_NAME} PRIVATE
 								DONT_SET_USING_JUCE_NAMESPACE=1
 								JucePlugin_PreferredChannelConfigurations={0,2}
 								_CRT_SECURE_NO_WARNINGS
+								JUCE_FORCE_USE_LEGACY_PARAM_IDS
 							)
 set(TARGET ${PLUGIN_NAME} PRIVATE CMAKE_CXX_STANDARD 20)
 

--- a/plugin/Source/AlignedArray.hpp
+++ b/plugin/Source/AlignedArray.hpp
@@ -4,21 +4,6 @@
 #include <cstddef>
 #include <memory>
 
-template<class T>
-class MySpan {
-public:
-    MySpan() = default;
-    MySpan(T* ptr, size_t size) : ptr_(ptr), size_(size) {}
-    T* Get() const { return ptr_; }
-    T& operator[](size_t i) {
-        assert(i < size_);
-        return ptr_[i];
-    }
-private:
-    T* ptr_{ nullptr };
-    size_t size_{ 0 };
-};
-
 template<class T, size_t aligenment>
 class AlignedArray {
 public:
@@ -68,14 +53,6 @@ public:
         return ptr_;
     }
 
-    MySpan<T> Span(size_t offset) const {
-        assert(offset < size_);
-        return {ptr_ + offset, size_ - offset};
-    }
-
-    MySpan<T> operator+(size_t offset) const {
-        return Span(offset);
-    }
 private:
     T* ptr_{ nullptr };
     size_t size_{ 0 };

--- a/plugin/Source/AlignedArray.hpp
+++ b/plugin/Source/AlignedArray.hpp
@@ -1,0 +1,63 @@
+#pragma once
+#include <cassert>
+#include <corecrt_malloc.h>
+#include <memory>
+
+template<class T>
+class MySpan {
+public:
+    MySpan() = default;
+    MySpan(T* ptr, size_t size) : ptr_(ptr), size_(size) {}
+    T* Get() const { return ptr_; }
+    T& operator[](size_t i) {
+        assert(i < size_);
+        return ptr_[i];
+    }
+private:
+    T* ptr_{ nullptr };
+    size_t size_{ 0 };
+};
+
+template<class T, size_t aligenment>
+class AlignedArray {
+public:
+    ~AlignedArray() {
+        Free();
+    }
+
+    void Free() {
+        if (ptr_) {
+            _aligned_free(ptr_);
+            ptr_ = nullptr;
+            size_ = 0;
+        }
+    }
+
+    void Reset(size_t size) {
+        Free();
+        ptr_ = (T*)_aligned_malloc(size * sizeof(T), aligenment);
+        std::fill_n(ptr_, size, T{});
+        size_ = size;
+    }
+
+    float& operator[](size_t i) {
+        assert(i < size_);
+        return ptr_[i];
+    }
+
+    float* Get() const {
+        return ptr_;
+    }
+
+    MySpan<T> Span(size_t offset) const {
+        assert(offset < size_);
+        return {ptr_ + offset, size_ - offset};
+    }
+
+    MySpan<T> operator+(size_t offset) const {
+        return Span(offset);
+    }
+private:
+    T* ptr_{ nullptr };
+    size_t size_{ 0 };
+};

--- a/plugin/Source/AlignedArray.hpp
+++ b/plugin/Source/AlignedArray.hpp
@@ -12,7 +12,7 @@ public:
     }
     void Free() {
         if (ptr_) {
-#ifdef _WINDOWS
+#ifdef _WIN32
             _aligned_free(ptr_);
 #else
             free(ptr_);
@@ -24,7 +24,7 @@ public:
 
     void Reset(size_t size) {
         Free();
-#ifdef _WINDOWS
+#ifdef _WIN32
         ptr_ = (T*)_aligned_malloc(size * sizeof(T), aligenment);
         if (!ptr_) assert(false);
 #else

--- a/plugin/Source/AlignedArray.hpp
+++ b/plugin/Source/AlignedArray.hpp
@@ -1,7 +1,6 @@
 #pragma once
-#include <assert.h>
 #include <cassert>
-#include <corecrt_malloc.h>
+#include <cstdlib>
 #include <cstddef>
 #include <memory>
 

--- a/plugin/Source/AlignedArray.hpp
+++ b/plugin/Source/AlignedArray.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <cassert>
 #include <corecrt_malloc.h>
+#include <cstddef>
 #include <memory>
 
 template<class T>
@@ -40,12 +41,21 @@ public:
         size_ = size;
     }
 
-    float& operator[](size_t i) {
+    T& operator[](size_t i) {
         assert(i < size_);
         return ptr_[i];
     }
 
-    float* Get() const {
+    T operator[](size_t i) const {
+        assert(i < size_);
+        return ptr_[i];
+    }
+
+    T* Get() {
+        return ptr_;
+    }
+
+    const T* Get() const {
         return ptr_;
     }
 

--- a/plugin/Source/PluginProcessor.cpp
+++ b/plugin/Source/PluginProcessor.cpp
@@ -160,6 +160,7 @@ PianoAudioProcessor::PianoAudioProcessor()
     params.add (addExtParam ("Downsample", "Downsample", "", "" , { 0.0f, 1.0f }, 0.0f, {0.0f}, textFunction));
     params.add (addExtParam ("LongModes", "Long Modes", "", "", { 0.0f, 1.0f }, 0.0f, {0.0f}, textFunction));
     params.add (addExtParam ("MaxTime", "Max Time", "", "", { 0.0f, 1.0f }, 0.0f, {0.0f}, textFunction));
+    params.add (addExtParam ("MultiThread", "MultiThread", "", "", { 0.0f, 1.0f }, 0.0f, {0.0f}, textFunction));
 
     init();
 }

--- a/plugin/Source/PluginProcessor.cpp
+++ b/plugin/Source/PluginProcessor.cpp
@@ -159,6 +159,7 @@ PianoAudioProcessor::PianoAudioProcessor()
     params.add (addExtParam ("Dwgs4", "Dwgs4", "", "" , { 0.0f, 1.0f }, 1.0f, {0.0f}, textFunction));
     params.add (addExtParam ("Downsample", "Downsample", "", "" , { 0.0f, 1.0f }, 0.0f, {0.0f}, textFunction));
     params.add (addExtParam ("LongModes", "Long Modes", "", "", { 0.0f, 1.0f }, 0.0f, {0.0f}, textFunction));
+    params.add (addExtParam ("MaxTime", "Max Time", "", "", { 0.0f, 1.0f }, 0.0f, {0.0f}, textFunction));
 
     init();
 }

--- a/plugin/Source/PluginProcessor.cpp
+++ b/plugin/Source/PluginProcessor.cpp
@@ -206,7 +206,6 @@ void PianoAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::
     for (auto p : params)
         piano.setParameter (idx++, p->getValue());
 
-    // auto ptr = (float**)buffer.getArrayOfWritePointers();
     std::span<float> leftBlock{ buffer.getWritePointer(0), static_cast<size_t>(buffer.getNumSamples()) };
     std::span<float> rightBlock{ buffer.getWritePointer(1), static_cast<size_t>(buffer.getNumSamples()) };
     piano.process (leftBlock, midi);

--- a/plugin/Source/PluginProcessor.cpp
+++ b/plugin/Source/PluginProcessor.cpp
@@ -146,7 +146,7 @@ PianoAudioProcessor::PianoAudioProcessor()
     params.add (addExtParam ("LongitudinalGamma", "Longitudinal Gamma", "", "" , { 0.0f, 1.0f }, 0.5f, {0.0f}, textFunction));
     params.add (addExtParam ("LongitudinalGammaQuadratic", "Longitudinal Gamma Quadratic", "", "" , { 0.0f, 1.0f }, 0.0f, {0.0f}, textFunction));
     params.add (addExtParam ("LongitudinalGammaDamped", "Longitudinal Gamma Damped", "", "" , { 0.0f, 1.0f }, 0.5f, {0.0f}, textFunction));
-    params.add (addExtParam ("LongitudinalGammaQuadraticDamped", "Longitudinal Gamma Quadratic Damped", "", "" , { 0.0f, 1.0f }, 0.0f, {0.0f}, textFunction));
+    params.add (addExtParam ("LongitudinalGammaQuadDamped", "Longitudinal Gamma Quad Damped", "", "" , { 0.0f, 1.0f }, 0.0f, {0.0f}, textFunction));
     params.add (addExtParam ("LongitudinalMix", "Longitudinal Mix", "", "" , { 0.0f, 1.0f }, 0.5f, {0.0f}, textFunction));
     params.add (addExtParam ("LongitudinalTransverseMix", "Longitudinal Transverse Mix", "", "" , { 0.0f, 1.0f }, 0.5f, {0.0f}, textFunction));
     params.add (addExtParam ("Volume", "Volume", "", "" , { 0.0f, 1.0f }, 0.5f, {0.0f}, textFunction));

--- a/plugin/Source/PluginProcessor.cpp
+++ b/plugin/Source/PluginProcessor.cpp
@@ -1,5 +1,7 @@
 #include "PluginProcessor.h"
 #include "PluginEditor.h"
+#include <cstddef>
+#include <span>
 
 static float userValue (int32_t index, float value)
 {
@@ -204,8 +206,11 @@ void PianoAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::
     for (auto p : params)
         piano.setParameter (idx++, p->getValue());
 
-    auto ptr = (float**)buffer.getArrayOfWritePointers();
-    piano.process (ptr, buffer.getNumSamples(), midi);
+    // auto ptr = (float**)buffer.getArrayOfWritePointers();
+    std::span<float> leftBlock{ buffer.getWritePointer(0), static_cast<size_t>(buffer.getNumSamples()) };
+    std::span<float> rightBlock{ buffer.getWritePointer(1), static_cast<size_t>(buffer.getNumSamples()) };
+    piano.process (leftBlock, midi);
+    std::copy(leftBlock.begin(), leftBlock.end(), rightBlock.begin());
 }
 
 //==============================================================================

--- a/plugin/Source/dwgs.cpp
+++ b/plugin/Source/dwgs.cpp
@@ -48,7 +48,7 @@ vec4 dwgs::tran2long4 (int delay)
     /* wave10[-del0] = x[cursor - del1] */
     n = delTab + 4;
     cur = (d1.cursor + DelaySize - delay + del0 - del1 + 1 ) % DelaySize;
-    wave10 = wave0 + delTab + 4;
+    wave10 = wave0.Get() + delTab + 4;
 
     if(n <= cur)
     {
@@ -87,7 +87,7 @@ vec4 dwgs::tran2long4 (int delay)
         x = d2.x;
         cur = (d2.cursor + DelaySize - delay - 4 + j + del4) % DelaySize;
 
-        float* wave10 = wave0 + j;
+        float* wave10 = wave0.Get() + j;
 #ifdef STRING_DEBUG
         for(int i=0; i<=delTab; i++)
             printf("%g ",wave10[i]);
@@ -99,7 +99,7 @@ vec4 dwgs::tran2long4 (int delay)
         if (n <= cur)
         {
             float *x1 = x + cur;
-            ms4 (wave10, x1 - n + 1, wave, n);
+            ms4 (wave10, x1 - n + 1, wave.Get(), n);
 
             /*
              for(int i=0; i<n; i++) {
@@ -110,7 +110,7 @@ vec4 dwgs::tran2long4 (int delay)
         else
         {
             float *x1 = x + cur;
-            ms4(wave10,x1-cur,wave,cur+1);
+            ms4(wave10,x1-cur,wave.Get(),cur+1);
             /*
              for(int i=0; i<=cur; i++) {
              wave1[i] = x1[-i];
@@ -129,7 +129,7 @@ vec4 dwgs::tran2long4 (int delay)
             }
 
             if(cur + 1 < n) {
-                ms4(wave10+cur+1,x1-n+1,wave+cur+1,n-cur-1);
+                ms4(wave10+cur+1,x1-n+1,wave.Get()+cur+1,n-cur-1);
                 /*
                  for(int i=cur+1; i<n; i++) {
                  wave1[i] = x1[-i];
@@ -145,7 +145,7 @@ vec4 dwgs::tran2long4 (int delay)
         printf("\n");
 #endif
 
-        diff4(wave, Fl, delTab+1);
+        diff4(wave.Get(), Fl.Get(), delTab+1);
 
 #ifdef LONG_DEBUG
         for(int i=0; i<=delTab; i++) {
@@ -156,8 +156,8 @@ vec4 dwgs::tran2long4 (int delay)
 
         out[j] = 0;
         for(int k=1; k<=nLongModes; k++) {
-            float *tab = modeTable[k];
-            float F = sse_dot (delTab + 4, tab, Fl);
+            float *tab = modeTable[k].Get();
+            float F = sse_dot (delTab + 4, tab, Fl.Get());
             float Fbl = longModeResonator[k].go (F);
             out[j] += Fbl;
         }
@@ -272,13 +272,17 @@ void dwgs::set(float Fs, int longmodes, int downsample, int upsample, float f, f
 
     //logf("%d %d %d %d %g %g\n", del0, del1, del2, del3, delta, delta2);
 
-    posix_memalign ((void**)&wave0, 32, size_t (delTab + 8) * sizeof(float));
-    posix_memalign ((void**)&wave1, 32, size_t (delTab + 8) * sizeof(float));
-    posix_memalign ((void**)&wave, 32, size_t (delTab + 8) * sizeof(float));
-    posix_memalign ((void**)&Fl, 32, size_t (delTab + 8) * sizeof(float));
-    memset (wave0, 0, size_t (delTab + 8) * sizeof(float));
-    memset (wave1, 0, size_t(delTab + 8) * sizeof(float));
-    memset (Fl, 0, size_t (delTab + 8) * sizeof(float));
+    // posix_memalign ((void**)&wave0, 32, size_t (delTab + 8) * sizeof(float));
+    // posix_memalign ((void**)&wave1, 32, size_t (delTab + 8) * sizeof(float));
+    // posix_memalign ((void**)&wave, 32, size_t (delTab + 8) * sizeof(float));
+    // posix_memalign ((void**)&Fl, 32, size_t (delTab + 8) * sizeof(float));
+    // memset (wave0, 0, size_t (delTab + 8) * sizeof(float));
+    // memset (wave1, 0, size_t(delTab + 8) * sizeof(float));
+    // memset (Fl, 0, size_t (delTab + 8) * sizeof(float));
+    wave0.Reset(delTab + 8);
+    wave1.Reset(delTab + 8);
+    wave.Reset(delTab + 8);
+    Fl.Reset(delTab + 8);
 
     //logf("dwgs top %d %d %d %d %g %g %g %g %g %g %g %g\n",del0,del1,del2,del3,dHammer+1+del2+dTop,del1+del3+dDispersion+lowpassdelay+dBottom, dTop, dBottom, dHammer, inpos*deltot, lowpassdelay, dDispersion);
 
@@ -303,8 +307,9 @@ void dwgs::set(float Fs, int longmodes, int downsample, int upsample, float f, f
         if(delTab) {
             float n = float (PI) * k / delHalf;
             // if(modeTable[k]) delete modeTable[k];
-            if (modeTable[k]) _aligned_free(modeTable[k]);
-            posix_memalign ((void**)&modeTable[k], 32, size_t (delTab + 8) * sizeof (float));
+            // if (modeTable[k]) _aligned_free(modeTable[k]);
+            // posix_memalign ((void**)&modeTable[k], 32, size_t (delTab + 8) * sizeof (float));
+            modeTable[k].Reset(delTab + 8);
 
             for (int i = 0; i <= delTab; i++)
             {
@@ -631,7 +636,7 @@ float dwgs::tran2long(int delay)
 
     x = d0.x;
     cur = (d0.cursor + DelaySize - delay) % DelaySize;
-    float *wave10 = wave + del2 + del4;
+    float *wave10 = wave.Get() + del2 + del4;
 
     if(del0 <= cur) {
         float *x1 = x + cur;
@@ -664,7 +669,7 @@ float dwgs::tran2long(int delay)
     /* wave10[-del0] = x[cursor - del1] */
 
     cur = (d1.cursor + DelaySize - delay + del0 - del1) % DelaySize;
-    wave10 = wave + delTab;
+    wave10 = wave.Get() + delTab;
     if(del0 < cur) {
         float *x1 = x + cur;
         for(int i=0; i>=-del0; i--) {
@@ -685,7 +690,7 @@ float dwgs::tran2long(int delay)
     x = d3.x;
     cur = (d3.cursor + DelaySize - delay) % DelaySize;
     n = del2 + del4;
-    wave10 = wave + n;
+    wave10 = wave.Get() + n;
     if(n < cur) {
         float *x1 = x + cur;
         for(int i=-1; i>=-n; i--) {
@@ -729,8 +734,8 @@ float dwgs::tran2long(int delay)
 
     float Fbl = 0;
     for(int k=1; k<=nLongModes; k++) {
-        float *tab = modeTable[k];
-        float F = sse_dot (delTab + 4, tab, Fl);
+        float *tab = modeTable[k].Get();
+        float F = sse_dot (delTab + 4, tab, Fl.Get());
 #ifdef LONGMODE_DEBUG
         cout << F << " ";
 #endif

--- a/plugin/Source/dwgs.cpp
+++ b/plugin/Source/dwgs.cpp
@@ -1,4 +1,5 @@
 #include "dwgs.h"
+#include <corecrt_malloc.h>
 #include <math.h>
 #include <stdio.h>
 #include "utils.h"
@@ -301,7 +302,10 @@ void dwgs::set(float Fs, int longmodes, int downsample, int upsample, float f, f
 #endif
         if(delTab) {
             float n = float (PI) * k / delHalf;
-            if(modeTable[k]) delete modeTable[k];
+            // if(modeTable[k]) delete modeTable[k];
+            if (modeTable[k]) {
+                _aligned_free(modeTable[k]);
+            }
             posix_memalign ((void**)&modeTable[k], 32, size_t (delTab + 8) * sizeof (float));
 
             for (int i = 0; i <= delTab; i++)

--- a/plugin/Source/dwgs.cpp
+++ b/plugin/Source/dwgs.cpp
@@ -1,5 +1,4 @@
 #include "dwgs.h"
-#include <corecrt_malloc.h>
 #include <math.h>
 #include <stdio.h>
 #include "utils.h"

--- a/plugin/Source/dwgs.cpp
+++ b/plugin/Source/dwgs.cpp
@@ -303,9 +303,7 @@ void dwgs::set(float Fs, int longmodes, int downsample, int upsample, float f, f
         if(delTab) {
             float n = float (PI) * k / delHalf;
             // if(modeTable[k]) delete modeTable[k];
-            if (modeTable[k]) {
-                _aligned_free(modeTable[k]);
-            }
+            if (modeTable[k]) _aligned_free(modeTable[k]);
             posix_memalign ((void**)&modeTable[k], 32, size_t (delTab + 8) * sizeof (float));
 
             for (int i = 0; i <= delTab; i++)

--- a/plugin/Source/dwgs.h
+++ b/plugin/Source/dwgs.h
@@ -2,7 +2,6 @@
 #define DWGS_H
 
 #include "filter.h"
-#include <crtdbg.h>
 #include "AlignedArray.hpp"
 
 class dwgs;

--- a/plugin/Source/dwgs.h
+++ b/plugin/Source/dwgs.h
@@ -3,58 +3,13 @@
 
 #include "filter.h"
 #include <crtdbg.h>
-#include <cstddef>
+#include "AlignedArray.hpp"
 
 class dwgs;
 
 enum {
     DelaySize = 4096,
     nMaxLongModes = 128
-};
-
-class MySpan {
-public:
-    MySpan() = default;
-    MySpan(float* ptr, size_t size) : ptr_(ptr), size_(size) {}
-    float& operator[](size_t i) { return ptr_[i]; }
-    float* Get() const { return ptr_; }
-private:
-    float* ptr_{ nullptr };
-    size_t size_{ 0 };
-};
-
-class AligendArray {
-public:
-    ~AligendArray() {
-        if (ptr_) {
-            _aligned_free(ptr_);
-        }
-    }
-
-    void Reset(size_t size) {
-        ptr_ = (float*)_aligned_malloc(size * sizeof(float), 32);
-        std::fill_n(ptr_, size, 0.0f);
-        size_ = size;
-    }
-
-    float& operator[](size_t i) {
-        return ptr_[i];
-    }
-
-    float* Get() const {
-        return ptr_;
-    }
-
-    MySpan Span(size_t offset) const {
-        return {ptr_ + offset, size_ - offset};
-    }
-
-    MySpan operator+(size_t offset) const {
-        return Span(offset);
-    }
-private:
-    float* ptr_{ nullptr };
-    size_t size_{ 0 };
 };
 
 class dwgs
@@ -89,10 +44,10 @@ public:
     // float *wave0;
     // float *wave1;
     // float *Fl;
-    AligendArray wave;
-    AligendArray wave0;
-    AligendArray wave1;
-    AligendArray Fl;
+    AlignedArray<float, 32> wave;
+    AlignedArray<float, 32> wave0;
+    AlignedArray<float, 32> wave1;
+    AlignedArray<float, 32> Fl;
     
     float F[nMaxLongModes];
     vec4 F4[nMaxLongModes];
@@ -120,7 +75,7 @@ public:
     
     // float *modeTable[nMaxLongModes];
     // float *modeTable4[nMaxLongModes];
-    AligendArray modeTable[nMaxLongModes];
+    AlignedArray<float, 32> modeTable[nMaxLongModes];
     float fLong[nMaxLongModes];
     DWGResonator longModeResonator[nMaxLongModes];
     

--- a/plugin/Source/dwgs.h
+++ b/plugin/Source/dwgs.h
@@ -37,8 +37,8 @@ public:
     vec4 tran2long4(int delay);
     int getDel2();
     
-    int downsample;
-    int delTab;
+    int downsample{};
+    int delTab{};
     // float *wave;
     // float *wave0;
     // float *wave1;
@@ -48,25 +48,25 @@ public:
     AlignedArray<float, 32> wave1;
     AlignedArray<float, 32> Fl;
     
-    float F[nMaxLongModes];
-    vec4 F4[nMaxLongModes];
+    float F[nMaxLongModes]{};
+    vec4 F4[nMaxLongModes]{};
     
-    float L;
-    float omega;
-    float f;
-    float inpos;
-    float B;
-    float longFreq1;
-    int nLongModes;
-    int upsample;
+    float L{};
+    float omega{};
+    float f{};
+    float inpos{};
+    float B{};
+    float longFreq1{};
+    int nLongModes{};
+    int upsample{};
     
-    int nDamper;
-    float c1;
-    float c3;
-    float c1M;
-    float c3M;
+    int nDamper{};
+    float c1{};
+    float c3{};
+    float c1M{};
+    float c3M{};
     
-    Loss loss;
+    Loss loss{};
     Thiran fracDelayTop;
     Thiran fracDelayBottom;
     Thiran hammerDelay;
@@ -75,31 +75,31 @@ public:
     // float *modeTable[nMaxLongModes];
     // float *modeTable4[nMaxLongModes];
     AlignedArray<float, 32> modeTable[nMaxLongModes];
-    float fLong[nMaxLongModes];
+    float fLong[nMaxLongModes]{};
     DWGResonator longModeResonator[nMaxLongModes];
     
-    float dDispersion;
-    float dTop;
-    float dHammer;
-    float dBottomAndLoss;
+    float dDispersion{};
+    float dTop{};
+    float dHammer{};
+    float dBottomAndLoss{};
     
-    float a0_0;
-    float a0_1, a0_2, a0_3, a0_4, a0_5;
-    float a1_1, a1_2, a1_3, a1_4, a1_5;
+    float a0_0{};
+    float a0_1{}, a0_2{}, a0_3{}, a0_4{}, a0_5{};
+    float a1_1{}, a1_2{}, a1_3{}, a1_4{}, a1_5{};
     
-    vec4 v0_0;
-    vec4 v0_1, v0_2, v0_3, v0_4, v0_5;
-    vec4 v1_1, v1_2, v1_3, v1_4, v1_5;
+    vec4 v0_0{};
+    vec4 v0_1{}, v0_2{}, v0_3{}, v0_4{}, v0_5{};
+    vec4 v1_1{}, v1_2{}, v1_3{}, v1_4{}, v1_5{};
     
     
-    int del0, del1, del2, del3, del4, del5;
+    int del0{}, del1{}, del2{}, del3{}, del4{}, del5{};
     Delay<DelaySize> d0;
     Delay<DelaySize> d1;
     Delay<DelaySize> d2;
     Delay<DelaySize> d3;
     
     
-    int M;
+    int M{};
 };
 
 #endif

--- a/plugin/Source/dwgs.h
+++ b/plugin/Source/dwgs.h
@@ -2,12 +2,59 @@
 #define DWGS_H
 
 #include "filter.h"
+#include <crtdbg.h>
+#include <cstddef>
 
 class dwgs;
 
 enum {
     DelaySize = 4096,
     nMaxLongModes = 128
+};
+
+class MySpan {
+public:
+    MySpan() = default;
+    MySpan(float* ptr, size_t size) : ptr_(ptr), size_(size) {}
+    float& operator[](size_t i) { return ptr_[i]; }
+    float* Get() const { return ptr_; }
+private:
+    float* ptr_{ nullptr };
+    size_t size_{ 0 };
+};
+
+class AligendArray {
+public:
+    ~AligendArray() {
+        if (ptr_) {
+            _aligned_free(ptr_);
+        }
+    }
+
+    void Reset(size_t size) {
+        ptr_ = (float*)_aligned_malloc(size * sizeof(float), 32);
+        std::fill_n(ptr_, size, 0.0f);
+        size_ = size;
+    }
+
+    float& operator[](size_t i) {
+        return ptr_[i];
+    }
+
+    float* Get() const {
+        return ptr_;
+    }
+
+    MySpan Span(size_t offset) const {
+        return {ptr_ + offset, size_ - offset};
+    }
+
+    MySpan operator+(size_t offset) const {
+        return Span(offset);
+    }
+private:
+    float* ptr_{ nullptr };
+    size_t size_{ 0 };
 };
 
 class dwgs
@@ -38,10 +85,14 @@ public:
     
     int downsample;
     int delTab;
-    float *wave;
-    float *wave0;
-    float *wave1;
-    float *Fl;
+    // float *wave;
+    // float *wave0;
+    // float *wave1;
+    // float *Fl;
+    AligendArray wave;
+    AligendArray wave0;
+    AligendArray wave1;
+    AligendArray Fl;
     
     float F[nMaxLongModes];
     vec4 F4[nMaxLongModes];
@@ -67,8 +118,9 @@ public:
     Thiran hammerDelay;
     ThiranDispersion dispersion[4];
     
-    float *modeTable[nMaxLongModes];
-    float *modeTable4[nMaxLongModes];
+    // float *modeTable[nMaxLongModes];
+    // float *modeTable4[nMaxLongModes];
+    AligendArray modeTable[nMaxLongModes];
     float fLong[nMaxLongModes];
     DWGResonator longModeResonator[nMaxLongModes];
     

--- a/plugin/Source/filter.cpp
+++ b/plugin/Source/filter.cpp
@@ -99,7 +99,10 @@ static float Db (float B, float f, int M)
 
 Filter::~Filter()
 {
-
+    _aligned_free(b);
+    _aligned_free(a);
+    _aligned_free(x);
+    _aligned_free(y);
 }
 
 Filter::Filter(int nmax_)

--- a/plugin/Source/filter.h
+++ b/plugin/Source/filter.h
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <iostream>
 #include <math.h>
+#include "AlignedArray.hpp"
 
 enum {
     MaxFilterUpsample = 8
@@ -22,10 +23,14 @@ public:
     float phasedelay(float omega);
     void init(int upsample = 1);
 
-    float *x;
-    float *y;
-    float *b;
-    float *a;
+    // float *x;
+    // float *y;
+    // float *b;
+    // float *a;
+    AlignedArray<float, 32> x;
+    AlignedArray<float, 32> y;
+    AlignedArray<float, 32> b;
+    AlignedArray<float, 32> a;
 
     float *bend;
     float *aend;

--- a/plugin/Source/filter.h
+++ b/plugin/Source/filter.h
@@ -23,34 +23,30 @@ public:
     float phasedelay(float omega);
     void init(int upsample = 1);
 
-    // float *x;
-    // float *y;
-    // float *b;
-    // float *a;
     AlignedArray<float, 32> x;
     AlignedArray<float, 32> y;
     AlignedArray<float, 32> b;
     AlignedArray<float, 32> a;
 
-    float *bend;
-    float *aend;
-    float *aend4;
+    float *bend{};
+    float *aend{};
+    float *aend4{};
 
-    float *xc;
-    float *yc;
+    float *xc{};
+    float *yc{};
 
-    float *xend;
-    float *yend;
+    float *xend{};
+    float *yend{};
 
     vec4 a0;
     vec4 a1;
     vec4 a2;
     vec4 a3;
 
-    int upsample;
-    int xskip;
-    int n;
-    int nmax;
+    int upsample{};
+    int xskip{};
+    int n{};
+    int nmax{};
 };
 
 class BiquadHP : public Filter 
@@ -107,9 +103,9 @@ template <int size>
 class Delay
 {
 public:
-    int di;
-    int d1;
-    int cursor;
+    int di{};
+    int d1{};
+    int cursor{};
 
     float* x;
     alignas(32) float x_[size+16];

--- a/plugin/Source/qiano.cpp
+++ b/plugin/Source/qiano.cpp
@@ -451,7 +451,8 @@ bool PianoNote::isDone()
     // return energy < e;
     // return (energy < 1e-8 * maxEnergy);
 
-    /* too small variation, see as slience */
+    /* too small variation, seen as slience */
+    /* this value will cut the note at almost -60dB */
     bool done = std::abs(lastOutput_ - currentOutput_) < 1e-1f;
     done |= std::isnan(lastOutput_);
     return done;

--- a/plugin/Source/qiano.cpp
+++ b/plugin/Source/qiano.cpp
@@ -322,13 +322,13 @@ vec4 PianoNote::go4()
      * this cause bool PianoNote::isDone() always return false
      * finnally, too many PianoNote instances cause cpu heavry
     */
-    // energy = energy + sum4 (simde_mm_sub_ps (simde_mm_mul_ps (output, output), simde_mm_mul_ps (delayed, delayed)));
-    // if(energy>maxEnergy)
-    //     maxEnergy = energy;
-    lastOutput_ = currentOutput_;
-    vec4 sum = simde_mm_hadd_ps(output, output);
-    vec4 sum2 = simde_mm_hadd_ps(sum, sum);
-    currentOutput_ = simde_mm_cvtss_f32(sum2);
+    energy = energy + sum4 (simde_mm_sub_ps (simde_mm_mul_ps (output, output), simde_mm_mul_ps (delayed, delayed)));
+    if(energy>maxEnergy)
+        maxEnergy = energy;
+    // lastOutput_ = currentOutput_;
+    // vec4 sum = simde_mm_hadd_ps(output, output);
+    // vec4 sum2 = simde_mm_hadd_ps(sum, sum);
+    // currentOutput_ = simde_mm_cvtss_f32(sum2);
 
 
     tTranRead = (tTranRead + 4)%TranBufferSize;
@@ -447,15 +447,15 @@ PianoNote::PianoNote (int note_, int Fs_, Piano* piano_)
 bool PianoNote::isDone()
 {
     //return false;
-    // float e = maxEnergy * 1e-8f;
-    // return energy < e;
-    // return (energy < 1e-8 * maxEnergy);
+    float e = maxEnergy * 1e-8f;
+    return energy < e;
+    return (energy < 1e-8 * maxEnergy);
 
     /* too small variation, seen as slience */
     /* this value will cut the note at almost -60dB */
-    bool done = std::abs(lastOutput_ - currentOutput_) < 1e-1f;
-    done |= std::isnan(lastOutput_);
-    return done;
+    // bool done = std::abs(lastOutput_ - currentOutput_) < 1e-1f;
+    // done |= std::isnan(lastOutput_);
+    // return done;
 }
 
 void PianoNote::triggerOn (float velocity, float* tune)
@@ -634,10 +634,10 @@ void PianoNote::triggerOn (float velocity, float* tune)
 
     hammer.set(resample*Fs,m,K,p,Z,alpha,maxDel2+128);
     hammer.strike(velocity);
-    // maxEnergy = 0.0;
-    // energy = 0.0;
-    lastOutput_ = 0.0f;
-    currentOutput_ = 0.0f;
+    maxEnergy = 0.0;
+    energy = 0.0;
+    // lastOutput_ = 0.0f;
+    // currentOutput_ = 0.0f;
 
 
     tranBridgeForce = Z;

--- a/plugin/Source/qiano.cpp
+++ b/plugin/Source/qiano.cpp
@@ -341,6 +341,7 @@ void Piano::init (float Fs_, int blockSize_)
 
 #if FDN_REVERB
     soundboard = std::make_unique<Reverb>(Fs);
+    soundboard->set (vals[pSoundboardSize], vals[pSoundboardDecay], vals[pSoundboardLopass]);
 #else
     soundboard = std::make_unique<ConvolveReverb<revSize>>(blockSize);
 #endif

--- a/plugin/Source/qiano.cpp
+++ b/plugin/Source/qiano.cpp
@@ -765,7 +765,7 @@ void Piano::process (std::span<float> block, juce::MidiBuffer& midi)
 
         size_t nextDelta = static_cast<size_t>(m.getTimeStamp());
         nextDelta = std::min (nextDelta, block.size());
-        process (block.subspan(delta));
+        process (block.subspan(delta, nextDelta - delta));
 
         if (m.getNoteNumber() >= PIANO_MIN_NOTE && m.getNoteNumber() <= PIANO_MAX_NOTE)
         {

--- a/plugin/Source/qiano.cpp
+++ b/plugin/Source/qiano.cpp
@@ -154,12 +154,10 @@ float PianoNote::goDownDelayed()
             simde_mm_store_ps(in, vec);
             vec = go4();
             simde_mm_store_ps(in + 4, vec);
-            // *((vec4*)in) = go4();
-            // *((vec4*)(in+4)) = go4();
         }
         else
         {
-            for(int i=0; i<8; i++)
+            for(int i = 0; i < 8; i++)
             {
                 in[i] = go();
             }
@@ -250,9 +248,9 @@ float PianoNote::go()
 
     //cout << output << "\n";
     float delayed = outputdelay.goDelay(output);
-    // energy = energy + output*output - delayed*delayed;
-    // if(energy>maxEnergy)
-    //     maxEnergy = energy;
+    energy = energy + output*output - delayed*delayed;
+    if(energy>maxEnergy)
+        maxEnergy = energy;
 
     tTranRead = (tTranRead + 1) % TranBufferSize;
 

--- a/plugin/Source/qiano.h
+++ b/plugin/Source/qiano.h
@@ -194,17 +194,16 @@ protected:
     std::vector<float> input;
     // multithread
     std::atomic<int> threadVoiceIndex_;
-    static constexpr int kNumThreads = 3;
+    static constexpr int kNumThreads = 1;
     struct ThreadData {
         ThreadData() : waiter(0) {}
         std::vector<float> buffer;
         std::binary_semaphore waiter;
-        std::atomic<bool> quit{ false };
         std::atomic<bool> complete{ false };
-        std::unique_ptr<std::jthread> thread;
+        std::unique_ptr<juce::Thread> thread;
         int size{};
     };
-    std::array<std::unique_ptr<ThreadData>, kNumThreads> threadDatas_;
+    std::array<ThreadData, kNumThreads> threadDatas_;
 
 #if FDN_REVERB
     std::unique_ptr<Reverb> soundboard;

--- a/plugin/Source/qiano.h
+++ b/plugin/Source/qiano.h
@@ -4,6 +4,7 @@
 
 #include <JuceHeader.h>
 #include <cstddef>
+#include <span>
 
 #define PIANO_MIN_NOTE 21
 #define PIANO_MAX_NOTE 108
@@ -100,16 +101,12 @@ public:
     bool isActive();
     void deActivate();
 
-    // PianoNote* next = nullptr;
-    // PianoNote* prev = nullptr;
     int note;
     Piano* piano = nullptr;
 
     bool isDone();
     float maxEnergy;
     float energy;
-    // float lastOutput_ = 0.0f;
-    // float currentOutput_ = 0.0f;
     Delay<65536> outputdelay;
     static void fillFrequencyTable();
     static double freqTable[NUM_NOTES];
@@ -143,9 +140,6 @@ protected:
     float f;
     int nstrings;
 
-    // dwgs* stringT[3];
-    // dwgs* stringHT[3];
-    // Hammer* hammer;
     dwgs stringT[3];
     dwgs stringHT[3];
     Hammer hammer;
@@ -176,9 +170,8 @@ public:
 
     void addVoice (PianoNote *v);
     void removeVoice (PianoNote *v);
-    void process (float *out, int samples);
-    void process (float **out, int frameSamples, int offset);
-    void process (float **out, int frameSamples, juce::MidiBuffer&);
+    void process (std::span<float> block);
+    void process (std::span<float> block, juce::MidiBuffer&);
     void init (float Fs, int blockSize);
     void triggerOn (int note, float velocity, float *tune);
 
@@ -191,19 +184,15 @@ public:
 protected:     
     friend class PianoNote;
     Value vals[NumParams];
-    // PianoNote* voiceList;
-    // PianoNote* noteArray[NUM_NOTES];
     std::array<PianoNote*, NUM_NOTES> voiceList{};
     size_t numActiveVoices = 0;
     std::array<std::unique_ptr<PianoNote>, NUM_NOTES> noteArray;
     int blockSize;
     float Fs;
-    // float* input = nullptr;
     std::vector<float> input;
 
 #if FDN_REVERB
     std::unique_ptr<Reverb> soundboard;
-    // Reverb *soundboard;
 #else
     std::unique_ptr<ConvolveReverb<revSize>> soundboard;
 #endif

--- a/plugin/Source/qiano.h
+++ b/plugin/Source/qiano.h
@@ -3,6 +3,7 @@
 #define PIANO_H
 
 #include <JuceHeader.h>
+#include <cstddef>
 
 #define PIANO_MIN_NOTE 21
 #define PIANO_MAX_NOTE 108
@@ -99,8 +100,8 @@ public:
     bool isActive();
     void deActivate();
 
-    PianoNote* next = nullptr;
-    PianoNote* prev = nullptr;
+    // PianoNote* next = nullptr;
+    // PianoNote* prev = nullptr;
     int note;
     Piano* piano = nullptr;
 
@@ -190,8 +191,10 @@ public:
 protected:     
     friend class PianoNote;
     Value vals[NumParams];
-    PianoNote* voiceList;
+    // PianoNote* voiceList;
     // PianoNote* noteArray[NUM_NOTES];
+    std::array<PianoNote*, NUM_NOTES> voiceList{};
+    size_t numActiveVoices = 0;
     std::array<std::unique_ptr<PianoNote>, NUM_NOTES> noteArray;
     int blockSize;
     float Fs;

--- a/plugin/Source/qiano.h
+++ b/plugin/Source/qiano.h
@@ -40,8 +40,8 @@ public:
     operator float() const {
         return v;
     }
-    float f;
-    float v;
+    float f{};
+    float v{};
 };
 
 enum parameters {

--- a/plugin/Source/qiano.h
+++ b/plugin/Source/qiano.h
@@ -23,7 +23,6 @@ enum {
     MaxDecimation = 16,
     MaxLongDelay = 16,
     TranBufferSize = 32,
-    NumParams = 34
 };
 
 class Param
@@ -78,7 +77,9 @@ enum parameters {
     pBridgeSpring,
     pDwgs4,
     pDownsample,
-    pLongModes
+    pLongModes,
+    pMaxTime,
+    NumParams
 };
 
 int getParameterIndex(const char *key);
@@ -102,6 +103,8 @@ public:
     void deActivate();
 
     int note;
+    int activeSampleAfterOff{};
+    bool triggerOn_{};
     Piano* piano = nullptr;
 
     bool isDone();

--- a/plugin/Source/qiano.h
+++ b/plugin/Source/qiano.h
@@ -142,9 +142,12 @@ protected:
     float f;
     int nstrings;
 
-    dwgs* stringT[3];
-    dwgs* stringHT[3];
-    Hammer* hammer;
+    // dwgs* stringT[3];
+    // dwgs* stringHT[3];
+    // Hammer* hammer;
+    dwgs stringT[3];
+    dwgs stringHT[3];
+    Hammer hammer;
 
     alignas(32) float outUp[8];
     alignas(32) float outDown[8];
@@ -188,15 +191,18 @@ protected:
     friend class PianoNote;
     Value vals[NumParams];
     PianoNote* voiceList;
-    PianoNote* noteArray[NUM_NOTES];
+    // PianoNote* noteArray[NUM_NOTES];
+    std::array<std::unique_ptr<PianoNote>, NUM_NOTES> noteArray;
     int blockSize;
     float Fs;
-    float* input = nullptr;
+    // float* input = nullptr;
+    std::vector<float> input;
 
-#ifdef FDN_REVERB
-    Reverb *soundboard;
+#if FDN_REVERB
+    std::unique_ptr<Reverb> soundboard;
+    // Reverb *soundboard;
 #else
-    ConvolveReverb<revSize> *soundboard;
+    std::unique_ptr<ConvolveReverb<revSize>> soundboard;
 #endif
 };
 

--- a/plugin/Source/qiano.h
+++ b/plugin/Source/qiano.h
@@ -105,8 +105,10 @@ public:
     Piano* piano = nullptr;
 
     bool isDone();
-    float maxEnergy;
-    float energy;
+    // float maxEnergy;
+    // float energy;
+    float lastOutput_ = 0.0f;
+    float currentOutput_ = 0.0f;
     Delay<65536> outputdelay;
     static void fillFrequencyTable();
     static double freqTable[NUM_NOTES];

--- a/plugin/Source/qiano.h
+++ b/plugin/Source/qiano.h
@@ -172,8 +172,6 @@ public:
     Piano();
     ~Piano();
 
-    void addVoice (PianoNote *v);
-    void removeVoice (PianoNote *v);
     void process (std::span<float> block);
     void process (std::span<float> block, juce::MidiBuffer&);
     void init (float Fs, int blockSize);

--- a/plugin/Source/qiano.h
+++ b/plugin/Source/qiano.h
@@ -186,7 +186,7 @@ public:
 
 protected:     
     friend class PianoNote;
-    Value vals[NumParams];
+    std::array<Value, NumParams> vals;
     std::array<PianoNote*, NUM_NOTES> voiceList{};
     size_t numActiveVoices = 0;
     std::array<std::unique_ptr<PianoNote>, NUM_NOTES> noteArray;

--- a/plugin/Source/qiano.h
+++ b/plugin/Source/qiano.h
@@ -105,10 +105,10 @@ public:
     Piano* piano = nullptr;
 
     bool isDone();
-    // float maxEnergy;
-    // float energy;
-    float lastOutput_ = 0.0f;
-    float currentOutput_ = 0.0f;
+    float maxEnergy;
+    float energy;
+    // float lastOutput_ = 0.0f;
+    // float currentOutput_ = 0.0f;
     Delay<65536> outputdelay;
     static void fillFrequencyTable();
     static double freqTable[NUM_NOTES];

--- a/plugin/Source/reverb.h
+++ b/plugin/Source/reverb.h
@@ -75,7 +75,6 @@ protected:
     float scale;
     
     Loss decay[ReverbTaps];
-    ConvolveReverb<revSize> *conv;
     float out;
 };
 

--- a/plugin/Source/reverb.h
+++ b/plugin/Source/reverb.h
@@ -61,21 +61,21 @@ public:
 protected:
     int getLength(int k);
     static int allLengths[NumLengths];
-    int lengths[ReverbTaps];
-    float Fs;
+    int lengths[ReverbTaps]{};
+    float Fs{};
     Delay<1024> d[ReverbTaps];
-    float o[ReverbTaps];
-    float b[ReverbTaps];
-    float c[ReverbTaps];
+    float o[ReverbTaps]{};
+    float b[ReverbTaps]{};
+    float c[ReverbTaps]{};
     
     vec4 o4[ReverbTaps];
     vec4 b4[ReverbTaps];
     vec4 c4[ReverbTaps];
     
-    float scale;
+    float scale{};
     
     Loss decay[ReverbTaps];
-    float out;
+    float out{};
 };
 
 #endif

--- a/plugin/Source/utils.cpp
+++ b/plugin/Source/utils.cpp
@@ -86,8 +86,13 @@ float sum4 (vec4 x)
 
 void ms4(float *x, float *y, float *z, int N)
 {
-    vec4 *x4 = (vec4*) x;
-    vec4 *z4 = (vec4*) z;
+    // vec4 *x4 = (vec4*) x;
+    // vec4 *z4 = (vec4*) z;
+    vec4 x4vec = simde_mm_loadu_ps(x);
+    vec4 *x4 = &x4vec;
+
+    vec4 z4vec = simde_mm_loadu_ps(z);
+    vec4 *z4 = &z4vec;
 
     int N4 = N >> 2;
     vec4 *zend = z4 + N4 + 1;
@@ -97,8 +102,10 @@ void ms4(float *x, float *y, float *z, int N)
     while (z4 < zend)
     {
         vec4 w = simde_mm_loadu_ps(y);
-        v = simde_mm_sub_ps (simde_mm_shuffle_ps (w, w, SIMDE_MM_SHUFFLE(0, 1, 2, 3)), *x4);
-        *z4 = simde_mm_mul_ps(v,v);
+        // v = simde_mm_sub_ps (simde_mm_shuffle_ps (w, w, SIMDE_MM_SHUFFLE(0, 1, 2, 3)), *x4);
+        // *z4 = simde_mm_mul_ps(v,v);
+        v = simde_mm_sub_ps(simde_mm_shuffle_ps(w, w, SIMDE_MM_SHUFFLE(0, 1, 2, 3)), *x4);
+        z4vec = simde_mm_mul_ps(v, v);
         x4++;
         y -= 4;
         z4++;


### PR DESCRIPTION
the threaded rendering can actully reduce cpu when massive notes playing, but it sometimes cause a peak cpu usage and audio glitch, so i set it to false default.